### PR TITLE
Avoid sending false value on foreach statement, when Cloudstack API returns empty response.

### DIFF
--- a/templates/method.php.twig
+++ b/templates/method.php.twig
@@ -96,12 +96,15 @@
 {% if method.list %}
         $items = $this->decodeBody($this->doRequest($req), '{{ method.name }}');
         $models = [];
-        unset($items['count']);
-        $items = reset($items);
-        foreach($items as $k => $item)
-        {
-            $models[] = new Response\{{ method.responseClassName }}($item);
+
+        if ($items) {
+            unset($items['count']);
+            $items = reset($items);
+            foreach($items as $item) {
+                $models[] = new Response\{{ method.responseClassName }}($item);
+            }
         }
+
         return $models;
 {% else %}
         return new Response\{{ method.responseClassName }}($this->decodeBody($this->doRequest($req), '{{ method.name }}'));


### PR DESCRIPTION
Avoid error from sending non array value to foreach statement, when Cloudstack API returns empty response.